### PR TITLE
Invalid laps

### DIFF
--- a/apps/python/PartyLaps/PartyLaps.py
+++ b/apps/python/PartyLaps/PartyLaps.py
@@ -480,6 +480,7 @@ class PartyLaps:
         self.bestLapAc = ac.getCarState(0, acsys.CS.BestLap)
 
         self.lapInvalidated = ac.getCarState(0, acsys.CS.LapInvalidated)
+        ac.log("acsys.CS.LapInvalidated: %s" %  (repr(self.lapInvalidated),))
 
         self.session = info.graphics.session
 

--- a/apps/python/PartyLaps/PartyLaps.py
+++ b/apps/python/PartyLaps/PartyLaps.py
@@ -276,7 +276,7 @@ class PartyLaps:
         self.sfCrossed = 0
         self.session = info.graphics.session
         self.lastSession = 0
-        self.lapInvalidated = 0
+        self.lapInvalidated = False
         self.justCrossedSf = False
         self.position = 0
         self.lastPosition = 0
@@ -479,8 +479,8 @@ class PartyLaps:
         self.lastPosition = self.currentPosition
         self.bestLapAc = ac.getCarState(0, acsys.CS.BestLap)
 
-        self.lapInvalidated = ac.getCarState(0, acsys.CS.LapInvalidated)
-        ac.console("acsys.CS.LapInvalidated: %s" %  (repr(self.lapInvalidated),))
+        self.lapInvalidated = info.physics.numberOfTyresOut == 4 or self.lapInvalidated
+        ac.console("Lap invalidated: %s" %  (repr(self.lapInvalidated),))
 
         self.session = info.graphics.session
 
@@ -545,6 +545,9 @@ class PartyLaps:
             self.performance = self.performanceAc + (self.bestLapAc - self.referenceTime)*self.position
 
     def updateDataNewLap(self):
+        """
+        A new lap has been started.
+        """
         self.lastLapDataRefreshed = self.lapDone
 
         # Reset
@@ -576,6 +579,7 @@ class PartyLaps:
 
         # Reset for the new lap
         self.currentLapData = [(0.0,0.0)]
+        self.lapInvalidated = False
 
         self.total += lapTime
         self.laps.append(lapTime)

--- a/apps/python/PartyLaps/PartyLaps.py
+++ b/apps/python/PartyLaps/PartyLaps.py
@@ -480,7 +480,7 @@ class PartyLaps:
         self.bestLapAc = ac.getCarState(0, acsys.CS.BestLap)
 
         self.lapInvalidated = ac.getCarState(0, acsys.CS.LapInvalidated)
-        ac.log("acsys.CS.LapInvalidated: %s" %  (repr(self.lapInvalidated),))
+        ac.console("acsys.CS.LapInvalidated: %s" %  (repr(self.lapInvalidated),))
 
         self.session = info.graphics.session
 

--- a/apps/python/PartyLaps/PartyLaps.py
+++ b/apps/python/PartyLaps/PartyLaps.py
@@ -565,7 +565,7 @@ class PartyLaps:
         if self.bestLapTimeSession == 0 or lapTime < self.bestLapTimeSession:
             self.bestLapTimeSession = lapTime
 
-        if not lockBest and (self.bestLapTime == 0 or lapTime < self.bestLapTime):
+        if not lockBest and (self.bestLapTime == 0 or lapTime < self.bestLapTime) and not self.lapInvalidated:
             # New record!
             self.bestLapTime = lapTime
             self.bestLapHolder = currentDriver
@@ -634,6 +634,9 @@ class PartyLaps:
             currentDriver if currentDriver != "" else "OPEN CONFIG TO SET DRIVERS")
 
     def updateViewNewLap(self):
+        """
+        Refresh the laps and the total.
+        """
         for index in range(lapDisplayedCount):
             lapIndex = index
             if len(self.laps) > lapDisplayedCount:


### PR DESCRIPTION
Closes #3.

This does not make the lap entries red, only the current lap time red, but it does correctly refuse to store a new invalid best lap time.

I will raise a new issue for displaying previous lap entries in red.
